### PR TITLE
remove `tailwindCSS.classAttributes` in settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,8 +32,6 @@
   },
 
   /* Extensions > Tailwind CSS IntelliSense */
-  // https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss#tailwindcss.classattributes
-  "tailwindCSS.classAttributes": ["class", "className", "ngClass", "class:list"],
   // https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss#tailwindcss.emmetcompletions
   "tailwindCSS.emmetCompletions": true,
 


### PR DESCRIPTION
`class:list` will be included by default in the as yet unreleased v0.11.

https://marketplace.visualstudio.com/items/bradlc.vscode-tailwindcss/changelog#user-content-0.11.x-(pre-release)