### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/yuheiy/sdenv/security/code-scanning/3](https://github.com/yuheiy/sdenv/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out the repository, setting up dependencies, and running build, test, and lint commands, it only requires `contents: read` permissions. This will ensure that the `GITHUB_TOKEN` has the minimal permissions necessary for the workflow to function.

The `permissions` block will be added at the root level of the workflow to apply to all jobs (`build`, `test`, and `lint`). This avoids redundancy and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
